### PR TITLE
Fixed link to NuGet package

### DIFF
--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -16,7 +16,7 @@ let info =
     "project-author", "Your Name"
     "project-summary", "A short summary of your project"
     "project-github", githubLink
-    "project-nuget", "http://nuget.com/packages/FSharp.Collections.ParallelSeq" ]
+    "project-nuget", "https://www.nuget.org/packages/FSharp.Collections.ParallelSeq" ]
 
 // --------------------------------------------------------------------------------------
 // For typical project, no changes are needed below


### PR DESCRIPTION
Link on the site is broken.
`nuget.org` should be instead of `nuget.com`
