### PR TITLE
workaround bug in ParallelEnumerable

### DIFF
--- a/src/FSharp.Collections.ParallelSeq/pseq.fs
+++ b/src/FSharp.Collections.ParallelSeq/pseq.fs
@@ -50,7 +50,7 @@ module PSeq =
         ParallelEnumerable.All(toP(s), Func<_,_>(p))
 
     let exists2 (f : 'T -> 'U -> bool) s1 s2 = 
-        ParallelEnumerable.Any(ParallelEnumerable.Zip(toP(s1), toP(s2),Func<_,_,_>(f)), Func<_,_>(id))
+        ParallelEnumerable.Any(ParallelEnumerable.Zip(toP(s1), toP(s2),Func<_,_,_>(f)))
 
     let forall2 (f : 'T -> 'U -> bool) s1 s2 = 
         ParallelEnumerable.All(ParallelEnumerable.Zip(toP(s1), toP(s2),Func<_,_,_>(f)), Func<_,_>(id))


### PR DESCRIPTION
@sergey-tihon See https://github.com/fsprojects/FSharp.Collections.ParallelSeq/issues/5 for an explanation of the issue.  It appears that using a different overload of ParallelEnumerable.Zip fixes the issue.